### PR TITLE
onprem: 2.4.5 patch

### DIFF
--- a/codefresh/Chart.lock
+++ b/codefresh/Chart.lock
@@ -64,64 +64,64 @@ dependencies:
   version: 1.14.13
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfapi
   repository: oci://quay.io/codefresh/charts
-  version: 21.253.44
+  version: 21.253.45
 - name: cfui
   repository: oci://quay.io/codefresh/charts
   version: 14.94.77
 - name: k8s-monitor
   repository: oci://quay.io/codefresh/charts
-  version: 4.11.6
+  version: 4.11.7
 - name: runtime-environment-manager
   repository: oci://quay.io/codefresh/charts
   version: 3.35.7
@@ -142,10 +142,10 @@ dependencies:
   version: 0.8.6
 - name: cf-platform-analytics
   repository: oci://quay.io/codefresh/charts
-  version: 0.49.52
+  version: 0.49.54
 - name: cf-platform-analytics
   repository: oci://quay.io/codefresh/charts
-  version: 0.49.52
+  version: 0.49.54
 - name: argo-platform
   repository: oci://quay.io/codefresh/charts
   version: 1.2944.1
@@ -155,5 +155,5 @@ dependencies:
 - name: cf-oidc-provider
   repository: oci://quay.io/codefresh/charts
   version: 0.0.15
-digest: sha256:6bcae4853d52aa868bbc651a847ffc9d5d0ba61d54b36d2118859aeeacdefe2e
-generated: "2024-07-22T10:53:22.504306253+03:00"
+digest: sha256:4ee2356ee0c50b458075c52aedeb1976da4bbe709089626164f32e22dbd218de
+generated: "2024-07-31T16:44:15.270805+03:00"

--- a/codefresh/Chart.yaml
+++ b/codefresh/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v2
 description: Helm Chart for Codefresh On-Prem
 name: codefresh
-version: 2.4.4
+version: 2.4.5
 keywords:
   - codefresh
 home: https://codefresh.io/
 icon: https://avatars1.githubusercontent.com/u/11412079?v=3
 sources:
-  - https://github.com/codefresh-io/cf-helm
+  - https://github.com/codefresh-io/codefresh-onprem-helm
 maintainers:
   - name: codefresh
     url: https://codefresh-io.github.io/
@@ -18,10 +18,10 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: fixed
-      description: "(gitops-platform) Fix ApplicationSet sync"
+      description: "(cf-api) Missing build logs with OfflineLogging and MongoDB 6.x"
       links:
         - name: JIRA Issue
-          url: https://codefresh-io.atlassian.net/browse/CR-23763
+          url: https://codefresh-io.atlassian.net/browse/CR-24606
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/codefresh/README.md
+++ b/codefresh/README.md
@@ -1,6 +1,6 @@
 ## Codefresh On-Premises
 
-![Version: 2.4.4](https://img.shields.io/badge/Version-2.4.4-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
+![Version: 2.4.5](https://img.shields.io/badge/Version-2.4.5-informational?style=flat-square) ![AppVersion: 2.4.0](https://img.shields.io/badge/AppVersion-2.4.0-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh On-Premises](https://codefresh.io/docs/docs/getting-started/intro-to-codefresh/) to Kubernetes.
 


### PR DESCRIPTION
## What
Patch for 2.4 release, fix for offline logging issue
## Why

## Notes

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build