### PR TITLE
CR-26762 - Correct the PROJECT_PIPELINES_LIMIT variable on-prem documentation with correct service

### DIFF
--- a/codefresh/README.md
+++ b/codefresh/README.md
@@ -1143,7 +1143,7 @@ cfapi:
 ### Projects pipelines limit
 
 ```yaml
-cfapi:
+pipeline-manager:
   env:
     # Determines project's pipelines limit (default: 500)
     PROJECT_PIPELINES_LIMIT: 500

--- a/codefresh/README.md.gotmpl
+++ b/codefresh/README.md.gotmpl
@@ -1148,7 +1148,7 @@ cfapi:
 ### Projects pipelines limit
 
 ```yaml
-cfapi:
+pipeline-manager:
   env:
     # Determines project's pipelines limit (default: 500)
     PROJECT_PIPELINES_LIMIT: 500


### PR DESCRIPTION
## What

## Why

## Notes

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build