### PR TITLE
docs(indexes): remove redundant TTL

### DIFF
--- a/indexes/codefresh/workflowprocesses.json
+++ b/indexes/codefresh/workflowprocesses.json
@@ -212,9 +212,6 @@
     {
         "keys": {
             "created": 1
-        },
-        "options": {
-            "expireAfterSeconds": 31536000
         }
     },
     {


### PR DESCRIPTION
## What

This removes TTL for `codefresh.workflowprocesses` as it's up to the customer to configure retention policy.

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build