### PR TITLE
docs: fix RabbitMQ version requirements

### DIFF
--- a/codefresh/Chart.yaml
+++ b/codefresh/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: Helm Chart for Codefresh On-Prem
 name: codefresh
-version: 2.8.10
+version: 2.8.11
 keywords:
   - codefresh
 home: https://codefresh.io/
@@ -18,8 +18,8 @@ annotations:
   # artifacthub.io/containsSecurityUpdates: "true"
   # supported kinds are added, changed, deprecated, removed, fixed and security.
   artifacthub.io/changes: |
-    - kind: security
-      description: "Contains security fixes"
+    - kind: fixed
+      description: "Fix RabbitMQ version requirements."
 dependencies:
   - name: cf-common
     repository: oci://quay.io/codefresh/charts

--- a/codefresh/README.md
+++ b/codefresh/README.md
@@ -1,6 +1,6 @@
 ## Codefresh On-Premises
 
-![Version: 2.8.10](https://img.shields.io/badge/Version-2.8.10-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
+![Version: 2.8.11](https://img.shields.io/badge/Version-2.8.11-informational?style=flat-square) ![AppVersion: 2.8.0](https://img.shields.io/badge/AppVersion-2.8.0-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh On-Premises](https://codefresh.io/docs/docs/getting-started/intro-to-codefresh/) to Kubernetes.
 
@@ -207,7 +207,7 @@ The following table displays the list of **persistent** services created as part
 | MongoDB      | Stores all account data (account settings, users, projects, pipelines, builds etc.)       | 7.x   |
 | Postgresql   | Stores data about events for the account (pipeline updates, deletes, etc.). The audit log uses the data from this database.        | 16.x or 17.x      |
 | Redis   | Used for caching, and as a key-value store for cron trigger manager.        | 7.0.x      |
-| RabbitMQ  | Used for message queueing.        | 4.0.x      |
+| RabbitMQ  | Used for message queueing.        | 3.13 \| 4.0.x      |
 
 > Running on netfs (nfs, cifs) is not recommended.
 

--- a/codefresh/README.md.gotmpl
+++ b/codefresh/README.md.gotmpl
@@ -208,7 +208,7 @@ The following table displays the list of **persistent** services created as part
 | MongoDB      | Stores all account data (account settings, users, projects, pipelines, builds etc.)       | 7.x   |
 | Postgresql   | Stores data about events for the account (pipeline updates, deletes, etc.). The audit log uses the data from this database.        | 16.x or 17.x      |
 | Redis   | Used for caching, and as a key-value store for cron trigger manager.        | 7.0.x      |
-| RabbitMQ  | Used for message queueing.        | 4.0.x      |
+| RabbitMQ  | Used for message queueing.        | 3.13 \| 4.0.x      |
 
 > Running on netfs (nfs, cifs) is not recommended.
 


### PR DESCRIPTION
## What

This fixes RabbitMQ version requirements, allowing it to use 3.13 with Codefresh installation.

3.13 is the latest version currently supported by Amazon MQ ([ref](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/rabbitmq-version-management.html))

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build