### PR TITLE
chore: updated argo-platform with security fixes to 1.3978.0-onprem-1819f07

### DIFF
--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -245,7 +245,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-platform
-    version: 1.3978.0
+    version: 1.3978.0-onprem-1819f07
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-hub-platform


### PR DESCRIPTION
## What

## Why

## Notes

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build