### PR TITLE
fix(jobs): upgrade `codefresh/mongosh`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Codefresh On-Premises
 
-![Version: 2.11.0-rc.1](https://img.shields.io/badge/Version-2.11.0--rc.1-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 2.11.0](https://img.shields.io/badge/Version-2.11.0-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 Helm chart for deploying [Codefresh On-Premises](https://codefresh.io/docs/docs/getting-started/intro-to-codefresh/) to Kubernetes.
 

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -36,7 +36,7 @@ seed:
     image:
       registry: us-docker.pkg.dev/codefresh-inc/public-gcr-io
       repository: codefresh/mongosh
-      tag: 2.5.10-cf-3
+      tag: 2.8.2-cf-1
     # -- Root user in plain text (required ONLY for seed job!).
     mongodbRootUser: "root"
     # -- Root user from existing secret
@@ -455,7 +455,7 @@ hooks:
     image:
       registry: us-docker.pkg.dev/codefresh-inc/public-gcr-io
       repository: codefresh/mongosh
-      tag: 2.5.10-cf-3
+      tag: 2.8.2-cf-1
     affinity: {}
     nodeSelector:
       kubernetes.io/arch: amd64


### PR DESCRIPTION
## What

This upgrades `codefresh/mongosh` to v2.8.2-cf-1 with fixes to `mongoimport` command.

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build