### PR TITLE
fix(internal-gateway): bump for security fixes

### DIFF
--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -22,9 +22,11 @@ annotations:
   #     description: ""
   artifacthub.io/changes: |
     - kind: changed
-      description: 'update "cf-broadcaster" to 1.15.9'
+      description: 'update "cf-broadcaster" to 1.15.11'
     - kind: changed
-      description: 'update "pipeline-manager" to 4.2.2'
+      description: 'update "k8s-monitor" to 4.12.2'
+    - kind: changed
+      description: 'update "pipeline-manager" to 4.2.3'
     - kind: changed
       description: 'update "context-manager" to 2.41.7'
     - kind: changed
@@ -110,7 +112,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: cfsign.enabled
   - name: tasker-kubernetes
-    version: 1.28.12
+    version: 1.29.1
     repository: oci://quay.io/codefresh/charts
     condition: tasker-kubernetes.enabled
   - name: context-manager
@@ -118,7 +120,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: context-manager.enabled
   - name: pipeline-manager
-    version: 4.2.2
+    version: 4.2.3
     repository: oci://quay.io/codefresh/charts
     condition: pipeline-manager.enabled
   - name: gitops-dashboard-manager
@@ -220,7 +222,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: cfui.enabled
   - name: k8s-monitor
-    version: 4.12.1
+    version: 4.12.2
     repository: oci://quay.io/codefresh/charts
     condition: k8s-monitor.enabled
   - name: runtime-environment-manager
@@ -228,7 +230,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: runtime-environment-manager.enabled
   - name: cf-broadcaster
-    version: 1.15.9
+    version: 1.15.11
     repository: oci://quay.io/codefresh/charts
     condition: cf-broadcaster.enabled
   - name: helm-repo-manager
@@ -262,7 +264,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-hub-platform
-    version: 0.1.35
+    version: 0.1.41
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: cf-oidc-provider

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -258,7 +258,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-platform
-    version: 1.4098.0
+    version: 1.4109.0
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-hub-platform

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -240,7 +240,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: hermes.enabled
   - name: nomios
-    version: 0.12.0
+    version: 0.12.2
     repository: oci://quay.io/codefresh/charts
     condition: hermes.enabled
   - name: cronus

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -236,7 +236,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: helm-repo-manager.enabled
   - name: hermes
-    version: 0.22.10
+    version: 0.22.11
     repository: oci://quay.io/codefresh/charts
     condition: hermes.enabled
   - name: nomios

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -249,12 +249,12 @@ dependencies:
     condition: hermes.enabled
   - name: cf-platform-analytics
     alias: cf-platform-analytics-platform
-    version: 0.54.6
+    version: 0.54.7
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: cf-platform-analytics
     alias: cf-platform-analytics-etlstarter
-    version: 0.54.6
+    version: 0.54.7
     repository: oci://quay.io/codefresh/charts
     condition: argo-platform.enabled
   - name: argo-platform

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -122,7 +122,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: pipeline-manager.enabled
   - name: gitops-dashboard-manager
-    version: 1.16.9
+    version: 1.16.12
     repository: oci://quay.io/codefresh/charts
     condition: gitops-dashboard-manager.enabled
   - name: cfapi

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -51,7 +51,7 @@ dependencies:
     version: 0.18.1
   - name: internal-gateway
     repository: oci://quay.io/codefresh/charts
-    version: 0.11.0
+    version: 0.12.3
     condition: internal-gateway.enabled
   - name: consul
     version: 11.4.32

--- a/charts/codefresh/Chart.yaml
+++ b/charts/codefresh/Chart.yaml
@@ -100,7 +100,7 @@ dependencies:
     repository: oci://quay.io/codefresh/charts
     condition: cluster-providers.enabled
   - name: kube-integration
-    version: 2.0.1
+    version: 2.1.2
     repository: oci://quay.io/codefresh/charts
     condition: kube-integration.enabled
   - name: charts-manager

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -540,7 +540,7 @@ runtimeImages:
   DOCKER_BUILDER_IMAGE: quay.io/codefresh/cf-docker-builder:1.6.4@sha256:616e8e173cd19eaa74c8c02bbcfa0514c95c2bf6ff9bc3838d1f35de499ff682
   DOCKER_PULLER_IMAGE: quay.io/codefresh/cf-docker-puller:8.0.34@sha256:9f6eb3b0084187a9a5bf751356104c2d99105d9a48794dcbb1cd07ade19b5909
   DOCKER_PUSHER_IMAGE: quay.io/codefresh/cf-docker-pusher:6.0.28@sha256:bea268ff4ba2132eec30cc3239334e847199be439fa0873b8b8ab21e6cc65a5f
-  ENGINE_IMAGE: quay.io/codefresh/engine:3.2.14@sha256:739ee01e0aa22270c9f6a0f3cca733548b6be5a158fcfa3c4de1227dc696cfcc
+  ENGINE_IMAGE: quay.io/codefresh/engine:3.2.20@sha256:fdb39ce04f713d970cf947368b5a1ee82a48b2071a2515966efb81ae6a6e621c
   FS_OPS_IMAGE: quay.io/codefresh/fs-ops:1.2.13@sha256:1f7ab2fddb3b8bb4153046261367e296c6c9ac3b224f48cd2028371a9f0e2bcf
   GIT_CLONE_IMAGE: quay.io/codefresh/cf-git-cloner:10.3.13@sha256:d5eae428c4896847795202036645a90fdad5f2f68a3eb08bf8ca7e65e450b5ed
   KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.2@sha256:a9642f66c7696367b43f2931bab6f647f9f91262e194609e64a19ea362a7c873

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -543,7 +543,7 @@ runtimeImages:
   ENGINE_IMAGE: quay.io/codefresh/engine:3.2.14@sha256:739ee01e0aa22270c9f6a0f3cca733548b6be5a158fcfa3c4de1227dc696cfcc
   FS_OPS_IMAGE: quay.io/codefresh/fs-ops:1.2.13@sha256:1f7ab2fddb3b8bb4153046261367e296c6c9ac3b224f48cd2028371a9f0e2bcf
   GIT_CLONE_IMAGE: quay.io/codefresh/cf-git-cloner:10.3.12@sha256:b820e97c9f40ee6dd6616168deeb90d6b2e969a9c0cd13ce4843692d8676676c
-  KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.1@sha256:b48c83479464e7d5b1fc0e46c7a310557823b5908f0024a5146086ab40e33706
+  KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.2@sha256:a9642f66c7696367b43f2931bab6f647f9f91262e194609e64a19ea362a7c873
   PIPELINE_DEBUGGER_IMAGE: quay.io/codefresh/cf-debugger:1.3.14@sha256:7a5890afcfdad4a9aa4eec1a218cb468d52855540c847b3809085415751bbaa7
   TEMPLATE_ENGINE: quay.io/codefresh/pikolo:0.15.2@sha256:f5ee6af6eda9476ef044703211ed00622db06bf74b1a74cbb97f2f847cb903a9
   CR_6177_FIXER: docker.io/library/alpine:3.23

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -861,7 +861,7 @@ cfsign:
       image:
         registry: us-docker.pkg.dev/codefresh-inc/public-gcr-io
         repository: codefresh/curl
-        tag: 8.17.0
+        tag: 8.20.0
   affinity: {}
   nodeSelector: {}
   podSecurityContext: {}
@@ -1311,7 +1311,7 @@ builder:
       image:
         registry: us-docker.pkg.dev/codefresh-inc/public-gcr-io
         repository: codefresh/curl
-        tag: 8.17.0
+        tag: 8.20.0
   container:
     image:
       registry: quay.io

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -535,10 +535,10 @@ postgresqlCleanJob:
 # @default -- See below
 runtimeImages:
   COMPOSE_IMAGE: quay.io/codefresh/compose:v5.1.4-1.6.6@sha256:62085a63c8452b1d3208c002051e89685499ff8372524b9ffaca4a3ef9b534c0
-  CONTAINER_LOGGER_IMAGE: quay.io/codefresh/cf-container-logger:2.0.24@sha256:6bd1cbb669b9e7b4c7bde98dc17d31f5b1d8373f981b7878d03dad17e4a7bc4b
+  CONTAINER_LOGGER_IMAGE: quay.io/codefresh/cf-container-logger:2.0.25@sha256:6cf9b4cfd8b550d1d95206a2d76adb217cca398e5067cb3c8e3d1d3939e1b878
   DIND_IMAGE: quay.io/codefresh/dind:29.5.3-3.0.17@sha256:a12a681c80cb619d5ea557f5873401eecae742bf108833cc8c69feabf8668e0f
   DOCKER_BUILDER_IMAGE: quay.io/codefresh/cf-docker-builder:1.6.4@sha256:616e8e173cd19eaa74c8c02bbcfa0514c95c2bf6ff9bc3838d1f35de499ff682
-  DOCKER_PULLER_IMAGE: quay.io/codefresh/cf-docker-puller:8.0.28@sha256:332cbc021029c1e8dccd7e90ce47832a2066b67ed4fc4c94e072b267ab44d72b
+  DOCKER_PULLER_IMAGE: quay.io/codefresh/cf-docker-puller:8.0.34@sha256:9f6eb3b0084187a9a5bf751356104c2d99105d9a48794dcbb1cd07ade19b5909
   DOCKER_PUSHER_IMAGE: quay.io/codefresh/cf-docker-pusher:6.0.28@sha256:bea268ff4ba2132eec30cc3239334e847199be439fa0873b8b8ab21e6cc65a5f
   ENGINE_IMAGE: quay.io/codefresh/engine:3.2.14@sha256:739ee01e0aa22270c9f6a0f3cca733548b6be5a158fcfa3c4de1227dc696cfcc
   FS_OPS_IMAGE: quay.io/codefresh/fs-ops:1.2.13@sha256:1f7ab2fddb3b8bb4153046261367e296c6c9ac3b224f48cd2028371a9f0e2bcf
@@ -546,7 +546,7 @@ runtimeImages:
   KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.2@sha256:a9642f66c7696367b43f2931bab6f647f9f91262e194609e64a19ea362a7c873
   PIPELINE_DEBUGGER_IMAGE: quay.io/codefresh/cf-debugger:1.3.14@sha256:7a5890afcfdad4a9aa4eec1a218cb468d52855540c847b3809085415751bbaa7
   TEMPLATE_ENGINE: quay.io/codefresh/pikolo:0.15.3@sha256:fc40fba6d9983b4360ba6ed02d7bf6ae8b7e9ee6c2f61649c165b120b174ca6d
-  CR_6177_FIXER: docker.io/library/alpine:3.23
+  CR_6177_FIXER: docker.io/library/alpine:latest
   GC_BUILDER_IMAGE: docker.io/library/alpine:3.23
 
 #--------------------

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -535,14 +535,14 @@ postgresqlCleanJob:
 # @default -- See below
 runtimeImages:
   COMPOSE_IMAGE: quay.io/codefresh/compose:v5.1.4-1.6.6@sha256:62085a63c8452b1d3208c002051e89685499ff8372524b9ffaca4a3ef9b534c0
-  CONTAINER_LOGGER_IMAGE: quay.io/codefresh/cf-container-logger:2.0.17@sha256:abef98caa641c974c59862307568d3436ab7d2ceb858a5d1c5e86b0764dc19eb
+  CONTAINER_LOGGER_IMAGE: quay.io/codefresh/cf-container-logger:2.0.24@sha256:6bd1cbb669b9e7b4c7bde98dc17d31f5b1d8373f981b7878d03dad17e4a7bc4b
   DIND_IMAGE: quay.io/codefresh/dind:29.5.3-3.0.17@sha256:a12a681c80cb619d5ea557f5873401eecae742bf108833cc8c69feabf8668e0f
-  DOCKER_BUILDER_IMAGE: quay.io/codefresh/cf-docker-builder:1.6.2@sha256:c50dc2797b7795314dfe1102494b3c474a5d463ed276a05b7ebfd4419451be45
+  DOCKER_BUILDER_IMAGE: quay.io/codefresh/cf-docker-builder:1.6.4@sha256:616e8e173cd19eaa74c8c02bbcfa0514c95c2bf6ff9bc3838d1f35de499ff682
   DOCKER_PULLER_IMAGE: quay.io/codefresh/cf-docker-puller:8.0.28@sha256:332cbc021029c1e8dccd7e90ce47832a2066b67ed4fc4c94e072b267ab44d72b
-  DOCKER_PUSHER_IMAGE: quay.io/codefresh/cf-docker-pusher:6.0.27@sha256:c31fb1facbccbcc4f48b669f168acc96cd695dfbabb5dea7b95af24a4b29aef2
+  DOCKER_PUSHER_IMAGE: quay.io/codefresh/cf-docker-pusher:6.0.28@sha256:bea268ff4ba2132eec30cc3239334e847199be439fa0873b8b8ab21e6cc65a5f
   ENGINE_IMAGE: quay.io/codefresh/engine:3.2.14@sha256:739ee01e0aa22270c9f6a0f3cca733548b6be5a158fcfa3c4de1227dc696cfcc
   FS_OPS_IMAGE: quay.io/codefresh/fs-ops:1.2.13@sha256:1f7ab2fddb3b8bb4153046261367e296c6c9ac3b224f48cd2028371a9f0e2bcf
-  GIT_CLONE_IMAGE: quay.io/codefresh/cf-git-cloner:10.3.12@sha256:b820e97c9f40ee6dd6616168deeb90d6b2e969a9c0cd13ce4843692d8676676c
+  GIT_CLONE_IMAGE: quay.io/codefresh/cf-git-cloner:10.3.13@sha256:d5eae428c4896847795202036645a90fdad5f2f68a3eb08bf8ca7e65e450b5ed
   KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.2@sha256:a9642f66c7696367b43f2931bab6f647f9f91262e194609e64a19ea362a7c873
   PIPELINE_DEBUGGER_IMAGE: quay.io/codefresh/cf-debugger:1.3.14@sha256:7a5890afcfdad4a9aa4eec1a218cb468d52855540c847b3809085415751bbaa7
   TEMPLATE_ENGINE: quay.io/codefresh/pikolo:0.15.2@sha256:f5ee6af6eda9476ef044703211ed00622db06bf74b1a74cbb97f2f847cb903a9

--- a/charts/codefresh/values.yaml
+++ b/charts/codefresh/values.yaml
@@ -545,7 +545,7 @@ runtimeImages:
   GIT_CLONE_IMAGE: quay.io/codefresh/cf-git-cloner:10.3.13@sha256:d5eae428c4896847795202036645a90fdad5f2f68a3eb08bf8ca7e65e450b5ed
   KUBE_DEPLOY: quay.io/codefresh/cf-deploy-kubernetes:18.0.2@sha256:a9642f66c7696367b43f2931bab6f647f9f91262e194609e64a19ea362a7c873
   PIPELINE_DEBUGGER_IMAGE: quay.io/codefresh/cf-debugger:1.3.14@sha256:7a5890afcfdad4a9aa4eec1a218cb468d52855540c847b3809085415751bbaa7
-  TEMPLATE_ENGINE: quay.io/codefresh/pikolo:0.15.2@sha256:f5ee6af6eda9476ef044703211ed00622db06bf74b1a74cbb97f2f847cb903a9
+  TEMPLATE_ENGINE: quay.io/codefresh/pikolo:0.15.3@sha256:fc40fba6d9983b4360ba6ed02d7bf6ae8b7e9ee6c2f61649c165b120b174ca6d
   CR_6177_FIXER: docker.io/library/alpine:3.23
   GC_BUILDER_IMAGE: docker.io/library/alpine:3.23
 


### PR DESCRIPTION
## What

fix https://linear.app/octopus/issue/CFS-11496/security-or-codefreshargo-platform-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-6323/security-or-codefreshargo-platform-or-cve-2026-33416-orlow
fix https://linear.app/octopus/issue/CFS-6321/security-or-codefreshargo-platform-or-cve-2026-33636-orlow
fix https://linear.app/octopus/issue/CFS-11491/security-or-nginxincnginx-unprivileged-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11537/security-or-codefreshcurl-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11865/security-or-codefreshcf-platform-analytics-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11876/security-or-codefreshhermes-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11923/security-or-codefreshnomios-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11909/security-or-codefreshgitops-dashboard-manager-or-cve-2026-45447-or
fix https://linear.app/octopus/issue/CFS-11777/security-or-codefreshcf-deploy-kubernetes-or-cve-2026-45447-or

## Why

## Notes

## PR Comments

Add the following comments to the PR:

`/test` - to trigger Onprem CI Build